### PR TITLE
Increase RDP clipboard ~256KB -> 5MB

### DIFF
--- a/src/protocols/rdp/client.h
+++ b/src/protocols/rdp/client.h
@@ -65,7 +65,7 @@
 /**
  * The maximum number of bytes to allow within the clipboard.
  */
-#define GUAC_RDP_CLIPBOARD_MAX_LENGTH 262144
+#define GUAC_RDP_CLIPBOARD_MAX_LENGTH (5*1024*1024)
 
 /**
  * Initial rate of audio to stream, in Hz. If the RDP server uses a different


### PR DESCRIPTION
A customer hit the 256KB limit when moving CSVs. 5MB seems both a negligible increase to me (considering gaucd containers have  a typical footprint of ~50MiB) whilst providing a 20 times larger clipboard.